### PR TITLE
Typescript typings improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,26 @@
-class PolyK {
-    static Slice(p: number[][][], ax: number, ay: number, bx: number, by: number)
+declare var PolyK: {
+    Slice(p: number[], ax: number, ay: number, bx: number, by: number): number[],
+    IsSimple(p: number[]): boolean,
+    IsConvex(p: number[]): boolean,
+    GetArea(p: number[]): number,
+    GetAABB(p: number[]): {},
+    Triangulate(p: number[]): number[],
+    ContainsPoint(p: number[], ax: number, ay: number): boolean,
+    Raycast(p: number[],x : number, y: number, dx: number, dy: number): RaycastResult,
+    ClosestEdge(p: number[], x: number, y: number): RaycastResult
 }
-namespace PolyK {}
+
+interface RaycastResult {
+    dist:number,
+    edge:number,
+    norm: {
+        x:number,
+        y:number
+    },
+    refl: {
+        x:number,
+        y:number
+    }
+}
+
 export = PolyK


### PR DESCRIPTION
* make PolyK generic object with methods instead of class with static methods (because the real PolyK object actually cannot serve as constructor, so having it as a class is misleading)
* add all PolyK methods
* remove namespace (I couldn't find a reason why it was there, sorry if I missed something)
* make polygon type as `number[]` instead of `number[][][]` (afaik PolyK polygon is just 1D array, isn't it?)